### PR TITLE
Various flags and small fixes for troubleshooting and speed tests

### DIFF
--- a/pcileech/device.c
+++ b/pcileech/device.c
@@ -305,7 +305,7 @@ BOOL DeviceRetrievePath(_Out_bytecap_(BufLen) LPWSTR wszDevicePath, _In_ ULONG B
 VOID DeviceOpen_SetPipePolicy(_In_ PDEVICE_DATA pDeviceData)
 {
 	BOOL boolTRUE = TRUE;
-	ULONG ulTIMEOUT = 100; // ms
+	ULONG ulTIMEOUT = 500; // ms
 	WinUsb_SetPipePolicy(pDeviceData->WinusbHandle, pDeviceData->PipeDmaOut, AUTO_CLEAR_STALL, (ULONG)sizeof(BOOL), &boolTRUE);
 	WinUsb_SetPipePolicy(pDeviceData->WinusbHandle, pDeviceData->PipeDmaOut, PIPE_TRANSFER_TIMEOUT, (ULONG)sizeof(BOOL), &ulTIMEOUT);
 	WinUsb_SetPipePolicy(pDeviceData->WinusbHandle, pDeviceData->PipeDmaIn1, AUTO_CLEAR_STALL, (ULONG)sizeof(BOOL), &boolTRUE);

--- a/pcileech/pcileech.h
+++ b/pcileech/pcileech.h
@@ -96,6 +96,10 @@ typedef struct tdConfig {
 	BOOL fPatchAll;
 	BOOL fForceRW;
 	BOOL fShowHelp;
+	BOOL fUse16MbReads;
+	BOOL fUse4MbReads;
+	BOOL fUse128KReads;
+	BOOL fDumpFile;
 } CONFIG, *PCONFIG;
 
 typedef struct tdPageStatistics {
@@ -103,6 +107,10 @@ typedef struct tdPageStatistics {
 	QWORD cPageSuccess;
 	QWORD cPageFail;
 	QWORD qwTickCountStart;
+	QWORD c4KReads;
+	QWORD c128KReads;
+	QWORD c4MbReads;
+	QWORD c16MbReads;
 	BOOL isAccessModeKMD;
 	LPSTR szCurrentAction;
 } PAGE_STATISTICS, *PPAGE_STATISTICS;

--- a/pcileech/util.c
+++ b/pcileech/util.c
@@ -462,8 +462,9 @@ VOID Util_Read1M(_In_ PCONFIG pCfg, _In_ PDEVICE_DATA pDeviceData, _Out_ PBYTE p
 	QWORD o, p;
 	// try read 1M in 128k chunks
 	for(o = 0; o < 0x00100000; o += 0x00020000) {
-		if((qwBaseAddress + o + 0x00020000 <= pCfg->qwAddrMax) && DeviceReadMEM(pDeviceData, qwBaseAddress + o, pbBuffer1M + o, 0x00020000, 0)) {
+		if ((pCfg->fUse128KReads) && ((qwBaseAddress + o + 0x00020000 <= pCfg->qwAddrMax) && DeviceReadMEM(pDeviceData, qwBaseAddress + o, pbBuffer1M + o, 0x00020000, 0))) {
 			pPageStat->cPageSuccess += 32;
+			pPageStat->c128KReads++;
 		} else {
 			// try read 128k in 4k (page) chunks
 			for(p = 0; p < 0x00020000; p += 0x1000) {
@@ -472,6 +473,7 @@ VOID Util_Read1M(_In_ PCONFIG pCfg, _In_ PDEVICE_DATA pDeviceData, _Out_ PBYTE p
 				}
 				if(DeviceReadMEM(pDeviceData, qwBaseAddress + o + p, pbBuffer1M + o + p, 0x1000, 0)) {
 					pPageStat->cPageSuccess++;
+					pPageStat->c4KReads++;
 				} else {
 					pPageStat->cPageFail++;
 				}
@@ -485,25 +487,34 @@ BOOL Util_Read16M(_In_ PCONFIG pCfg, _In_ PDEVICE_DATA pDeviceData, _Out_ PBYTE 
 	BOOL isSuccess[4] = { FALSE, FALSE, FALSE, FALSE };
 	QWORD i, o, qwOffset;
 	// try read 16M
-	if((qwBaseAddress + 0x01000000 <= pCfg->qwAddrMax) && DeviceReadMEM(pDeviceData, qwBaseAddress, pbBuffer16M, 0x01000000, 0)) {
-		pPageStat->cPageSuccess += 4096;
-		return TRUE;
+	if (pCfg->fUse16MbReads != FALSE) {
+		if((qwBaseAddress + 0x01000000 <= pCfg->qwAddrMax) && DeviceReadMEM(pDeviceData, qwBaseAddress, pbBuffer16M, 0x01000000, 0)) {
+			pPageStat->cPageSuccess += 4096;
+			pPageStat->c16MbReads++;
+			return TRUE;
+		}
 	}
+
 	// try read 16M in 4M chunks
 	memset(pbBuffer16M, 0, 0x01000000);
-	for(i = 0; i < 4; i++) {
-		o = 0x00400000 * i;
-		isSuccess[i] = (qwBaseAddress + o + 0x00400000 <= pCfg->qwAddrMax) && DeviceReadMEM(pDeviceData, qwBaseAddress + o, pbBuffer16M + o, 0x00400000, 0);
+
+	if (pCfg->fUse4MbReads != FALSE) {
+		for(i = 0; i < 4; i++) {
+			o = 0x00400000 * i;
+			isSuccess[i] = (qwBaseAddress + o + 0x00400000 <= pCfg->qwAddrMax) && DeviceReadMEM(pDeviceData, qwBaseAddress + o, pbBuffer16M + o, 0x00400000, 0);
+		}
+		// DMA mode + all memory inside scope + and all 4M reads fail => fail
+		if(!pDeviceData->KMDHandle && qwBaseAddress + 0x01000000 <= pCfg->qwAddrMax && !isSuccess[0] && !isSuccess[1] && !isSuccess[2] && !isSuccess[3]) {
+			pPageStat->cPageFail += 4096;
+			return FALSE;
+		}
 	}
-	// DMA mode + all memory inside scope + and all 4M reads fail => fail
-	if(!pDeviceData->KMDHandle && qwBaseAddress + 0x01000000 <= pCfg->qwAddrMax && !isSuccess[0] && !isSuccess[1] && !isSuccess[2] && !isSuccess[3]) {
-		pPageStat->cPageFail += 4096;
-		return FALSE;
-	}
+
 	// try read failed 4M chunks in 1M chunks
 	for(i = 0; i < 4; i++) {
 		if(isSuccess[i]) {
 			pPageStat->cPageSuccess += 1024;
+			pPageStat->c4MbReads++;
 		} else {
 			qwOffset = 0x00400000 * i;
 			for(o = 0; o < 0x00400000; o += 0x00100000) {


### PR DESCRIPTION
- Add a feature to control if 128K, 4MB, or 16MB reads should be supported [-no16M, -no4M, -no128K]. Allows trying out different read mechanisms potentially for troubleshooting or speed measurement. Also return status on which read sizes were used.
- "Force" flag should not cause bail out if 16MB consecutive region has failed -- there may be (and often are) MMIO gaps after a while which still contain OS data.
- Use SwitchToThread instead of Sleep(0), since that's the actual behavior desired.
- Use 500ms pipe timeout
- Fix a typo
- Support full memory read without an actual "dump" [-noout] to disk. Useful for testing/speed measurement/demo.