### PR TITLE
[Fix] 22.9.7: DriverVer set to incorrect date

### DIFF
--- a/pcileech_flash/windows/PCILeechFlash/PCILeechFlash.vcxproj
+++ b/pcileech_flash/windows/PCILeechFlash/PCILeechFlash.vcxproj
@@ -62,11 +62,13 @@
     <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
     <OutDir>$(SolutionDir)\pcileech_files\flash\</OutDir>
     <IntDir>$(SolutionDir)\pcileech_files\temp\</IntDir>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
     <OutDir>$(SolutionDir)\pcileech_files\flash\</OutDir>
     <IntDir>$(SolutionDir)\pcileech_files\temp\</IntDir>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>


### PR DESCRIPTION
Fix
Signability test failed,
22.9.7: DriverVer set to incorrect date (postdated DriverVer not allowed).
I use GMT+7 clock, this will fix to people who use other time zone than UTC.

more information here:
https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/15ed3c14-5d54-4d17-ab12-7ac171c3ab5c/2297-driverver-set-to-incorrect-date-postdated-driverver-not-allowed-in-netlwfinf?forum=wdk