### PR TITLE
Imply -v on -vv

### DIFF
--- a/pcileech/Makefile
+++ b/pcileech/Makefile
@@ -14,18 +14,17 @@ OBJ  = oscompatibility.o charutil.o device.o pcileech.o executor.o extra.o help.
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 pcileech: $(OBJ)
-	cp ../files/vmm.so . || cp ../../MemProcFS*/files/vmm.so . || true
-	cp ../files/leechcore.so . || cp ../../LeechCore*/files/leechcore.so . || true
+	-cp ../files/vmm.so . || cp ../../MemProcFS*/files/vmm.so .
+	-cp ../files/leechcore.so . || cp ../../LeechCore*/files/leechcore.so .
 	$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS)
-	mv pcileech ../files/ |true
-	mv vmm.so ../files/ |true
-	mv leechcore.so ../files/ |true
-	rm -f *.o || true
-	rm -f */*.o || true
-	rm -f *.so || true
-	true
+	-mv pcileech ../files/
+	-mv vmm.so ../files/
+	-mv leechcore.so ../files/
+	-rm -f *.o
+	-rm -f */*.o
+	-rm -f *.so
 
 clean:
-	rm -f *.o || true
-	rm -f */*.o || true
-	rm -f *.so || true
+	-rm -f *.o
+	-rm -f */*.o
+	-rm -f *.so

--- a/pcileech/Makefile.macos
+++ b/pcileech/Makefile.macos
@@ -25,20 +25,21 @@ OBJ_ARM64  = $(OBJ:.o=.o.arm64)
 
 all: pcileech
 
+leechcore.dylib:
+	cp ../files/leechcore.dylib . || cp ../../LeechCore*/files/leechcore.dylib .
+
 %.o.x86_64: %.c $(DEPS)
 	$(CC) $(CFLAGS_X86_64) -c -o $@ $<
 
 %.o.arm64: %.c $(DEPS)
 	$(CC) $(CFLAGS_ARM64) -c -o $@ $<
 
-pcileech_x86_64: $(OBJ_X86_64)
+pcileech_x86_64: $(OBJ_X86_64) leechcore.dylib
 	cp ../files/vmm.dylib . || cp ../../MemProcFS*/files/vmm.dylib . || true
-	cp ../files/leechcore.dylib . || cp ../../LeechCore*/files/leechcore.dylib . || true
 	$(CC) $(LDFLAGS_X86_64) -o $@ $^
 
-pcileech_arm64: $(OBJ_ARM64)
+pcileech_arm64: $(OBJ_ARM64) leechcore.dylib
 	cp ../files/vmm.dylib . || cp ../../MemProcFS*/files/vmm.dylib . || true
-	cp ../files/leechcore.dylib . || cp ../../LeechCore*/files/leechcore.dylib . || true
 	$(CC) $(LDFLAGS_ARM64) -o $@ $^
 
 pcileech: pcileech_x86_64 pcileech_arm64

--- a/pcileech/Makefile.macos
+++ b/pcileech/Makefile.macos
@@ -26,7 +26,10 @@ OBJ_ARM64  = $(OBJ:.o=.o.arm64)
 all: pcileech
 
 leechcore.dylib:
-	cp ../files/leechcore.dylib . || cp ../../LeechCore*/files/leechcore.dylib .
+	cp ../../LeechCore*/files/leechcore.dylib . || cp ../files/leechcore.dylib .
+
+vmm.dylib:
+	cp ../../MemProcFS*/files/vmm.dylib . || cp ../files/vmm.dylib .
 
 %.o.x86_64: %.c $(DEPS)
 	$(CC) $(CFLAGS_X86_64) -c -o $@ $<
@@ -34,26 +37,27 @@ leechcore.dylib:
 %.o.arm64: %.c $(DEPS)
 	$(CC) $(CFLAGS_ARM64) -c -o $@ $<
 
-pcileech_x86_64: $(OBJ_X86_64) leechcore.dylib
-	cp ../files/vmm.dylib . || cp ../../MemProcFS*/files/vmm.dylib . || true
+pcileech_x86_64: $(OBJ_X86_64) leechcore.dylib vmm.dylib
 	$(CC) $(LDFLAGS_X86_64) -o $@ $^
 
 pcileech_arm64: $(OBJ_ARM64) leechcore.dylib
-	cp ../files/vmm.dylib . || cp ../../MemProcFS*/files/vmm.dylib . || true
 	$(CC) $(LDFLAGS_ARM64) -o $@ $^
 
 pcileech: pcileech_x86_64 pcileech_arm64
 	lipo -create -output pcileech pcileech_x86_64 pcileech_arm64
 	install_name_tool -id @rpath/pcileech pcileech
-	mv pcileech ../files/ |true
-	mv vmm.dylib ../files/ |true
-	mv leechcore.dylib ../files/ |true
-	rm -f *.o *.o.x86_64 *.o.arm64 || true
-	rm -f */*.o */*.o.x86_64 */*.o.arm64 || true
-	rm -f *.dylib || true
-	true
+	-mv pcileech ../files/
+	-mv vmm.dylib ../files/
+	-mv leechcore.dylib ../files/
+	-rm -f *.o *.o.x86_64 *.o.arm64
+	-rm -f */*.o */*.o.x86_64 */*.o.arm64
+	-rm -f *.dylib
+	-rm -f pcileech_arm64
+	-rm -r pcileech_x86_64
 
 clean:
-	rm -f *.o *.o.x86_64 *.o.arm64 || true
-	rm -f */*.o */*.o.x86_64 */*.o.arm64 || true
-	rm -f *.dylib || true
+	-rm -f *.o *.o.x86_64 *.o.arm64
+	-rm -f */*.o */*.o.x86_64 */*.o.arm64
+	-rm -f *.dylib
+	-rm -f pcileech_arm64
+	-rm -r pcileech_x86_64

--- a/pcileech/help.c
+++ b/pcileech/help.c
@@ -110,9 +110,9 @@ VOID Help_ShowGeneral()
         "   -v   : verbose option. Additional information is displayed in the output.   \n" \
         "          Affects all modes and commands. Option has no value. Example: -v     \n" \
         "   -vv  : extra verbose option. More detailed additional information is shown  \n" \
-        "          in output. Option has no value. Example: -vv                         \n" \
+        "          in output. Implies -v. Option has no value. Example: -vv             \n" \
         "   -vvv : super verbose option. Show all data transferred such as PCIe TLPs.   \n" \
-        "          Option has no value. Example: -vvv                                   \n" \
+        "          Does NOT imply -v or -vv. Option has no value. Example: -vvv         \n" \
         "   -force: force reads and writes even though target memory is marked as not   \n" \
         "          accessible. Dangerous! Affects all modes and commands.               \n" \
         "          Option has no value. Example: -force                                 \n" \

--- a/pcileech/pcileech.c
+++ b/pcileech/pcileech.c
@@ -134,6 +134,7 @@ BOOL PCILeechConfigIntialize(_In_ DWORD argc, _In_ char* argv[])
             i++;
             continue;
         } else if(0 == _stricmp(argv[i], "-vv")) {
+            ctxMain->cfg.fVerbose = TRUE;
             ctxMain->cfg.fVerboseExtra = TRUE;
             i++;
             continue;


### PR DESCRIPTION
Always imply -v on -vv.
Since the behavior of -vvv is different it might be an idea to rename this parameter?

I also cleaned the Makefiles a bit. Is there a specific reason you always clean the object files? The main idea of Make is to avoid recompilation if the source code has not changed, but that is now no longer possible.

BSD Zero Clause License

Copyright (c) 2026 Remco Poelstra

Permission to use, copy, modify, and/or distribute this software for any
purpose with or without fee is hereby granted.

THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
PERFORMANCE OF THIS SOFTWARE.